### PR TITLE
Dockerfile changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM fpco/stack-build
 MAINTAINER Michael Litchard
-RUN apt-get upgrade && apt-get update
-RUN apt-get install git
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get -y install git
 RUN git clone https://github.com/mlitchard/swiftfizz.git
 WORKDIR /swiftfizz
+RUN stack setup
 RUN stack install
 ENTRYPOINT ["/root/.local/bin/swiftfizz-exe"]


### PR DESCRIPTION
Reversed order of apt-get update and upgrade so that the upgrade will
happen reliably and with the updated package list.

Added confirmation flag (`-y`) to relevant apt-get invocations so that
it won't abort on confirmation requests.

Added stack setup to satisfy GHC version requirement without pinning
the underlying fpco/stack-build image changes.